### PR TITLE
Cache GitHub 404 responses in order to prevent making many XHR calls …

### DIFF
--- a/src/get-package-name/__tests__/fetch-package-name.test.js
+++ b/src/get-package-name/__tests__/fetch-package-name.test.js
@@ -43,7 +43,7 @@ describe('fetchPackageName', () => {
     expect(packageName).toBe('vue')
   })
 
-  it('returns null if api returns with 404', async () => {
+  it('returns N/A if api returns with 404', async () => {
     fetch.mockImplementation((url) => {
       return Promise.resolve({
         status: 404
@@ -51,8 +51,8 @@ describe('fetchPackageName', () => {
     })
 
     const packageName = await fetchPackageName('vuejs', 'vue')
-    expect(packageName).toBeNull()
-    expect(console.warn).toHaveBeenCalled()
+    expect(packageName).toBe('N/A')
+    expect(console.warn).not.toHaveBeenCalled()
   })
 
   it('returns null if api returns with 403', async () => {

--- a/src/get-package-name/__tests__/get-package-name.test.js
+++ b/src/get-package-name/__tests__/get-package-name.test.js
@@ -10,6 +10,13 @@ import getCachedPackageMock from '../get-cached-package'
 import isFreshMock from '../is-fresh'
 import createPackageMock from '../create-package'
 
+afterEach(() => {
+  getCacheKeyMock.mockReset()
+  getCachedPackageMock.mockReset()
+  isFreshMock.mockReset()
+  createPackageMock.mockReset()
+})
+
 describe('getPackageName', () => {
   it('returns name from cached package if cache is still fresh', async () => {
     const cachedPackage = { name: 'vue' }
@@ -30,6 +37,7 @@ describe('getPackageName', () => {
   it('creates package if cache is stale or it doesn`t exist', async () => {
     const pkg = { name: 'vuex' }
 
+    getCacheKeyMock.mockReturnValue('cache-key')
     isFreshMock.mockReturnValue(false)
     createPackageMock.mockReturnValue(Promise.resolve(pkg))
 
@@ -44,6 +52,16 @@ describe('getPackageName', () => {
     createPackageMock.mockReturnValue(Promise.resolve(null))
 
     const packageName = await getPackageName('vuejs', 'vue')
+
+    expect(packageName).toBeNull()
+  })
+
+  it ('returns null if repo doesn`t belong to a npm package', async () => {
+    const cachedPackage = { name: 'N/A' }
+    getCachedPackageMock.mockReturnValue(Promise.resolve(cachedPackage))
+    isFreshMock.mockReturnValue(true)
+
+    const packageName = await getPackageName('ipython', 'ipython')
 
     expect(packageName).toBeNull()
   })

--- a/src/get-package-name/fetch-package-name.js
+++ b/src/get-package-name/fetch-package-name.js
@@ -2,14 +2,14 @@ const fetchPackageName = (owner, repo) => {
   return fetch(`https://api.github.com/repos/${owner}/${repo}/contents/package.json`)
     .then(response => {
       if (response.status === 403) throw new Error('Hourly GitHub api rate limit exceeded')
-      if (response.status === 404) throw new Error('package.json is not found')
+      if (response.status === 404) return 'N/A'
       return response.json()
     })
     .then(response => {
+      if (response === 'N/A') return response
+
       const packageJson = JSON.parse(atob(response.content))
-      if (packageJson.private) {
-        return null
-      }
+      if (packageJson.private) return null
       return packageJson.name
     })
     .catch((error) => {

--- a/src/get-package-name/get-package-name.js
+++ b/src/get-package-name/get-package-name.js
@@ -7,7 +7,7 @@ const getPackageName = async (owner, repo) => {
   const cacheKey = getCacheKey(owner, repo)
   let pkg = await getCachedPackage(cacheKey)
   if (!isFresh(pkg)) pkg = await createPackage(cacheKey, owner, repo)
-  return pkg ? pkg.name : null
+  return pkg && pkg.name !== 'N/A' ? pkg.name : null
 }
 
 export default getPackageName


### PR DESCRIPTION
…for a non-npm package repo