### PR TITLE
Check for and 4xx status in registry

### DIFF
--- a/src/get-package-name/resolve-private-package.js
+++ b/src/get-package-name/resolve-private-package.js
@@ -3,7 +3,7 @@ import getRepoInfo from '../get-repo-info'
 const resolvePrivatePackage = async (owner, repo, packageName) => {
   const response = await fetch(`https://registry.npmjs.org/${packageName}/latest`)
 
-  if (response.status === 404) {
+  if (Math.floor(response.status / 100) === 4) {
     console.warn(`[github-npm-stats] Couldn't find "${packageName}" in npm registry`)
     return null
   }


### PR DESCRIPTION
In case of a scope that does not exist or the current user have no access to, the response code will be 401 (unauthorized).
This check check against all 4xx codes and prevents a runtime error in trying to call `json` function on a non-existing response.

![](https://user-images.githubusercontent.com/516342/51861761-b18c7a80-2345-11e9-8c13-a69b1be9e158.png)