### PR TITLE
z-index over 9k

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -6,7 +6,7 @@ ul.pagehead-actions .npm-stats .btn svg {
 ul.pagehead-actions .npm-stats .select-menu-modal {
   width: 400px;
   left: -55px;
-  z-index: 1;
+  z-index: 9999;
 }
 
 ul.pagehead-actions .npm-stats--inside .select-menu-modal {


### PR DESCRIPTION
Ahhh it looks like refined github changed some css? A z-index of 1 is now not enough.

![Screen Shot 2020-05-30 at 4 43 04 PM](https://user-images.githubusercontent.com/12915163/83338676-af696180-a294-11ea-95fd-3f7bc211cd86.png)


Here's a PR for you to consider. 

I'm hoping `9999` is enough to keep this issue from reoccurring, but when it comes to browser extensions it's anyone's guess. The proper solution is likely the custom CSS approach that I posted previously, and if this happens again I'll do that instead of asking you to release a new version.