### PR TITLE
repo's missing packageJson.name

### DIFF
--- a/src/get-package-name/create-package.js
+++ b/src/get-package-name/create-package.js
@@ -13,6 +13,7 @@ const createPackage = async (cacheKey, owner, repo) => {
     if (chrome.runtime.lastError) {
       console.warn(chrome.runtime.lastError)
     }
+    // if there is no error, perhaps some local storage flag "logging" flag could be set
   })
 
   return pkg


### PR DESCRIPTION
this is really an issue, but the tracker is disabled, which I totally understand. Will be attaching some screenshots with some bits from going into the debugger

not working on ReactTraining/history or facebook/create-react-app, since they are missing a packageJson.name

Works for me on https://github.com/primefaces/primereact#readme

<img width="1625" alt="CleanShot 2020-09-10 at 11 05 38@2x" src="https://user-images.githubusercontent.com/539816/92760755-96258600-f356-11ea-86ce-9acf16d03584.png">

<img width="1680" alt="CleanShot 2020-09-10 at 11 08 54@2x" src="https://user-images.githubusercontent.com/539816/92760906-bd7c5300-f356-11ea-9ac9-52a79edd1586.png">

<img width="1680" alt="CleanShot 2020-09-10 at 11 09 53@2x" src="https://user-images.githubusercontent.com/539816/92760924-c10fda00-f356-11ea-8416-05f01161bb91.png">

I think maybe there could be a console log of:
> github npm stats: repo package.json has no "name" property, cannot determine npm package name

This way developers can see the extension is working properly but the repo just doesn't have the proper meta data to find the npm package name