### PR TITLE
Exclude VSCode packages

### DIFF
--- a/src/get-package-name/fetch-package-name.js
+++ b/src/get-package-name/fetch-package-name.js
@@ -17,7 +17,12 @@ const fetchPackageName = async (owner, repo) => {
   let packageName = packageJson.name
   const isVscodeExtension = Boolean(packageJson.engines?.vscode && packageJson.publisher)
 
-  if (!packageName || isVscodeExtension) {
+  if (isVscodeExtension) {
+    console.warn('[github-npm-stats] Error: Manifest is for a Visual Studio Code extension')
+    return null
+  }
+
+  if (!packageName) {
     return 'N/A'
   }
 

--- a/src/get-package-name/fetch-package-name.js
+++ b/src/get-package-name/fetch-package-name.js
@@ -15,8 +15,9 @@ const fetchPackageName = async (owner, repo) => {
   const responseBody = await response.json()
   const packageJson = JSON.parse(atob(responseBody.content))
   let packageName = packageJson.name
+  const isVscodeExtension = Boolean(packageJson.engines?.vscode && packageJson.publisher)
 
-  if (!packageName) {
+  if (!packageName || isVscodeExtension) {
     return 'N/A'
   }
 


### PR DESCRIPTION
This browser extension also displays stats for VSCode extension that share the name with an npm package ([example](https://github.com/idleberg/vscode-applescript)). This PR adds a check for [required properties](https://code.visualstudio.com/api/references/extension-manifest) in the manifest of a VSCode extension.